### PR TITLE
automate certificate renew. close #2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,8 +22,19 @@ services:
     volumes:
       - ${PWD}/central:/var/www/central
       - ${PWD}/nginx.conf:/etc/nginx/nginx.conf
+      - ./data/certbot/conf:/etc/letsencrypt
+      - ./data/certbot/www:/var/www/certbot
+            
     ports:
       - "80:80"
+      - "443:443"
+  certbot:
+    image: certbot/certbot
+    restart: unless-stopped
+    volumes:
+      - ./data/certbot/conf:/etc/letsencrypt
+      - ./data/certbot/www:/var/www/certbot
+    entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"
 networks:
   artipie-net:
     driver: bridge

--- a/init-letsencrypt.sh
+++ b/init-letsencrypt.sh
@@ -5,8 +5,7 @@ if ! [ -x "$(command -v docker-compose)" ]; then
   exit 1
 fi
 
-#domains=(central.artipie.com www.central.artipie.com)
-domains=(ec2-18-188-223-13.us-east-2.compute.amazonaws.com www.ec2-18-188-223-13.us-east-2.compute.amazonaws.com)
+domains=(central.artipie.com www.central.artipie.com)
 rsa_key_size=4096
 data_path="./data/certbot"
 email=artem.lazarev@gmail.com"" # Adding a valid address is strongly recommended

--- a/init-letsencrypt.sh
+++ b/init-letsencrypt.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+if ! [ -x "$(command -v docker-compose)" ]; then
+  echo 'Error: docker-compose is not installed.' >&2
+  exit 1
+fi
+
+#domains=(central.artipie.com www.central.artipie.com)
+domains=(ec2-18-188-223-13.us-east-2.compute.amazonaws.com www.ec2-18-188-223-13.us-east-2.compute.amazonaws.com)
+rsa_key_size=4096
+data_path="./data/certbot"
+email=artem.lazarev@gmail.com"" # Adding a valid address is strongly recommended
+staging= # Set to 1 if you're testing your setup to avoid hitting request limits
+
+if [ -d "$data_path" ]; then
+  read -p "Existing data found for $domains. Continue and replace existing certificate? (y/N) " decision
+  if [ "$decision" != "Y" ] && [ "$decision" != "y" ]; then
+    exit
+  fi
+fi
+
+
+if [ ! -e "$data_path/conf/options-ssl-nginx.conf" ] || [ ! -e "$data_path/conf/ssl-dhparams.pem" ]; then
+  echo "### Downloading recommended TLS parameters ..."
+  mkdir -p "$data_path/conf"
+  curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot-nginx/certbot_nginx/_internal/tls_configs/options-ssl-nginx.conf > "$data_path/conf/options-ssl-nginx.conf"
+  curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot/certbot/ssl-dhparams.pem > "$data_path/conf/ssl-dhparams.pem"
+  echo
+fi
+
+echo "### Creating dummy certificate for $domains ..."
+path="/etc/letsencrypt/live/$domains"
+mkdir -p "$data_path/conf/live/$domains"
+docker-compose run --rm --entrypoint "\
+  openssl req -x509 -nodes -newkey rsa:1024 -days 1\
+    -keyout '$path/privkey.pem' \
+    -out '$path/fullchain.pem' \
+    -subj '/CN=localhost'" certbot
+echo
+
+
+echo "### Starting nginx ..."
+docker-compose up --force-recreate -d nginx
+echo
+
+echo "### Deleting dummy certificate for $domains ..."
+docker-compose run --rm --entrypoint "\
+  rm -Rf /etc/letsencrypt/live/$domains && \
+  rm -Rf /etc/letsencrypt/archive/$domains && \
+  rm -Rf /etc/letsencrypt/renewal/$domains.conf" certbot
+echo
+
+
+echo "### Requesting Let's Encrypt certificate for $domains ..."
+#Join $domains to -d args
+domain_args=""
+for domain in "${domains[@]}"; do
+  domain_args="$domain_args -d $domain"
+done
+
+# Select appropriate email arg
+case "$email" in
+  "") email_arg="--register-unsafely-without-email" ;;
+  *) email_arg="--email $email" ;;
+esac
+
+# Enable staging mode if needed
+if [ $staging != "0" ]; then staging_arg="--staging"; fi
+
+docker-compose run --rm --entrypoint "\
+  certbot certonly --webroot -w /var/www/certbot \
+    $staging_arg \
+    $email_arg \
+    $domain_args \
+    --rsa-key-size $rsa_key_size \
+    --agree-tos \
+    --force-renewal" certbot
+echo
+
+echo "### Reloading nginx ..."
+docker-compose exec nginx nginx -s reload

--- a/nginx.conf
+++ b/nginx.conf
@@ -2,8 +2,11 @@ events {
 
 }
 http {
-  server {
+server {
     listen 80;
+    server_name ec2-user@ec2-18-188-223-13.us-east-2.compute.amazonaws.com;
+    server_tokens off;
+        
     
     rewrite ^/$ /central redirect;
 
@@ -14,6 +17,24 @@ http {
     location /central {
       autoindex on;
       root /var/www;
+    }
+  }
+
+server {
+    listen 443 ssl;
+    server_name ec2-18-188-223-13.us-east-2.compute.amazonaws.com;
+    server_tokens off;
+
+    ssl_certificate /etc/letsencrypt/live/example.org/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/example.org/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+    location / {
+        proxy_pass  http://ec2-18-188-223-13.us-east-2.compute.amazonaws.com;
+        proxy_set_header    Host                $http_host;
+        proxy_set_header    X-Real-IP           $remote_addr;
+        proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
     }
   }
 }

--- a/nginx.conf
+++ b/nginx.conf
@@ -4,7 +4,7 @@ events {
 http {
 server {
     listen 80;
-    server_name ec2-user@ec2-18-188-223-13.us-east-2.compute.amazonaws.com;
+    server_name central.artipie.com;
     server_tokens off;
         
     
@@ -22,7 +22,7 @@ server {
 
 server {
     listen 443 ssl;
-    server_name ec2-18-188-223-13.us-east-2.compute.amazonaws.com;
+    server_name central.artipie.com;
     server_tokens off;
 
     ssl_certificate /etc/letsencrypt/live/example.org/fullchain.pem;
@@ -31,7 +31,7 @@ server {
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 
     location / {
-        proxy_pass  http://ec2-18-188-223-13.us-east-2.compute.amazonaws.com;
+        proxy_pass  http://central.artipie.com;
         proxy_set_header    Host                $http_host;
         proxy_set_header    X-Real-IP           $remote_addr;
         proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;


### PR DESCRIPTION
Added letsencrypt SSL certificate and automate certificate renew using Docker-compose + Nginx.
Not tested in case of Letsencrypt policy about EC2 instance. We will test on production.
