### PR TITLE
Add action for deploy and gitignore

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,30 @@
+name: "Deploy Artipie"
+on:
+  push:
+    branches:
+      - "master"
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - name: Deploy to Server
+        uses: easingthemes/ssh-deploy@2.2.11
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SERVER_SSH_KEY }}
+          REMOTE_HOST: ${{ secrets.REMOTE_HOST }}
+          REMOTE_USER: ${{ secrets.REMOTE_USER }}
+          REMOTE_PORT: ${{ secrets.REMOTE_PORT }}
+          TARGET: ${{ secrets.REMOTE_TARGET }}
+          EXCLUDE: ".github/, .gitignore"
+      - name: Build, remove old container and up a new one
+        env:
+          SSH_REMOTE_USER: ${{ secrets.REMOTE_USER }}
+          SSH_REMOTE_HOST: ${{ secrets.REMOTE_HOST }}
+        run: |
+          docker context create remote ‐‐docker "host=ssh://$SSH_REMOTE_USER@$SSH_REMOTE_HOST"
+          docker context use remote
+          docker-compose build
+          docker-compose pull artipie
+          docker-compose down
+          docker-compose up -d

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+target/
+.idea/
+classes/
+*.iml
+.DS_Store
+*.pdf
+*.aux
+*.log
+*.bcf
+*.bbl
+*.fdb_latexmk
+*.fls
+*.run.xml
+*.blg
+.classpath
+.project
+.vscode/


### PR DESCRIPTION
Part of #14 
Added action for deploy to workflow.
It is necessary to specify the next values in secrets: `SERVER_SSH_KEY`, `REMOTE_HOST`, `REMOTE_USER`, `REMOTE_PORT`, `REMOTE_TARGET`