### PR TITLE
ci: add `deploy` label

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: "Deploy Artipie"
 on: [push]
 jobs:
   deploy:
-    runs-on: [self-hosted]
+    runs-on: [self-hosted, deploy]
     environment: Prod
     steps:
       - uses: actions/checkout@v2.3.4


### PR DESCRIPTION
A new runner was added on the organization level therefore it is necessary to add `deploy` label here to avoid ambiguity.