### PR TITLE
New Artipie frontend support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - ARTIPIE_USER_NAME
       - ARTIPIE_USER_PASS
       - ARTIPIE_SESSION_KEY
+      - TKN_KEY
     volumes:
       - /var/artipie:/var/artipie
       - ./artipie.yml:/etc/artipie.yml
@@ -22,6 +23,8 @@ services:
       - ./artipie.yml:/etc/artipie.yml
     networks:
       - artipie-net
+    environment:
+      - TKN_KEY
   central-auth:
     image: g4s8/artipie-auth:latest
     container_name: central-auth

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,9 @@ services:
     environment:
       - TKN_KEY
   central-auth:
-    image: g4s8/artipie-auth:latest
+    build:
+      context: ./login
+      dockerfile: Dockerfile
     container_name: central-auth
     environment:
       - OAUTH_CLIENT

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.3"
 services:
   artipie:
-    image: artipie/artipie:v0.23.1
+    image: artipie/artipie:v0.23.10
     container_name: artipie
     restart: unless-stopped
     environment:
@@ -14,7 +14,7 @@ services:
     networks:
       - artipie-net
   front:
-    image: artipie/front:v0.0.2
+    image: artipie/front:v0.0.3
     container_name: front
     restart: unless-stopped
     volumes:

--- a/init-letsencrypt.sh
+++ b/init-letsencrypt.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+if ! [ -x "$(command -v docker-compose)" ]; then
+  echo 'Error: docker-compose is not installed.' >&2
+  exit 1
+fi
+
+domains=(central.artipie.com)
+rsa_key_size=4096
+data_path="./data/certbot"
+email="chgena@mail.ru"  # Adding a valid address is strongly recommended
+staging= # Set to 1 if you're testing your setup to avoid hitting request limits
+
+if [ -d "$data_path" ]; then
+  read -p "Existing data found for $domains. Continue and replace existing certificate? (y/N) " decision
+  if [ "$decision" != "Y" ] && [ "$decision" != "y" ]; then
+    exit
+  fi
+fi
+
+
+if [ ! -e "$data_path/conf/options-ssl-nginx.conf" ] || [ ! -e "$data_path/conf/ssl-dhparams.pem" ]; then
+  echo "### Downloading recommended TLS parameters ..."
+  mkdir -p "$data_path/conf"
+  curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot-nginx/certbot_nginx/_internal/tls_configs/options-ssl-nginx.conf > "$data_path/conf/options-ssl-nginx.conf"
+  curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot/certbot/ssl-dhparams.pem > "$data_path/conf/ssl-dhparams.pem"
+  echo
+fi
+
+echo "### Creating dummy certificate for $domains ..."
+path="/etc/letsencrypt/live/$domains"
+mkdir -p "$data_path/conf/live/$domains"
+docker-compose run --rm --entrypoint "\
+  openssl req -x509 -nodes -newkey rsa:1024 -days 1\
+    -keyout '$path/privkey.pem' \
+    -out '$path/fullchain.pem' \
+    -subj '/CN=localhost'" certbot
+echo
+
+
+echo "### Starting nginx ..."
+docker-compose up --force-recreate -d nginx
+echo
+
+echo "### Deleting dummy certificate for $domains ..."
+docker-compose run --rm --entrypoint "\
+  rm -Rf /etc/letsencrypt/live/$domains && \
+  rm -Rf /etc/letsencrypt/archive/$domains && \
+  rm -Rf /etc/letsencrypt/renewal/$domains.conf" certbot
+echo
+
+
+echo "### Requesting Let's Encrypt certificate for $domains ..."
+#Join $domains to -d args
+domain_args=""
+for domain in "${domains[@]}"; do
+  domain_args="$domain_args -d $domain"
+done
+
+# Select appropriate email arg
+case "$email" in
+  "") email_arg="--register-unsafely-without-email" ;;
+  *) email_arg="--email $email" ;;
+esac
+
+# Enable staging mode if needed
+if [ "$staging" != "0" ]; then staging_arg="--staging"; fi
+
+docker-compose run --rm --entrypoint "\
+  certbot certonly --webroot -w /var/www/certbot \
+    $staging_arg \
+    $email_arg \
+    $domain_args \
+    --rsa-key-size $rsa_key_size \
+    --agree-tos \
+    --force-renewal" certbot
+echo
+
+echo "### Reloading nginx ..."
+docker-compose exec nginx nginx -s reload

--- a/nginx.conf
+++ b/nginx.conf
@@ -34,7 +34,7 @@ http {
     }
 
     location /auth {
-      proxy_pass http://central-auth:8080;
+      proxy_pass http://central-auth:80;
       proxy_set_header Host $http_host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -47,8 +47,8 @@ http {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 
-    location /dashboard {
-      proxy_pass http://front;
+    location ~ ^/(dashboard|signin) {
+      proxy_pass http://front:8080;
       proxy_set_header Host $http_host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/restart.sh
+++ b/restart.sh
@@ -4,6 +4,7 @@ export OAUTH_CLIENT="0f33052d9fee8303c36e"
 export OAUTH_SECRET="e57d898182a2f68d9a44c1c69a892a1b66e85be0"
 export SESSION_KEY="/var/artipie/keys/artipie.der"
 export ARTIPIE_SESSION_KEY="/var/artipie/keys/artipie-priv.der"
+export TKN_KEY="" #variable must be set for artipie/front for future GitHub API integration
 
 docker-compose build
 docker-compose pull artipie

--- a/restart.sh
+++ b/restart.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+export OAUTH_CLIENT="0f33052d9fee8303c36e"
+export OAUTH_SECRET="e57d898182a2f68d9a44c1c69a892a1b66e85be0"
+export SESSION_KEY="/var/artipie/keys/artipie.der"
+export ARTIPIE_SESSION_KEY="/var/artipie/keys/artipie-priv.der"
+
+docker-compose build
+docker-compose pull artipie
+docker-compose down
+docker-compose up -d


### PR DESCRIPTION
Updated server & scripts to new versions of artipie & artipie/front.
GitHub auth. component currently doesn't work with new frontend, but builds & runs correctly.
https://artipie.com
https://central.artipie.com/signin
Old artipie/frontend branch with required scripts was prepared too, for backup purposes:
https://github.com/artipie/central/tree/old-frontend