### PR TITLE
Let's crypt init fix

### DIFF
--- a/init-letsencrypt.sh
+++ b/init-letsencrypt.sh
@@ -9,7 +9,7 @@ domains=(central.artipie.com)
 rsa_key_size=4096
 data_path="./data/certbot"
 email="chgena@mail.ru"  # Adding a valid address is strongly recommended
-staging= # Set to 1 if you're testing your setup to avoid hitting request limits
+staging=0 # Set to 1 if you're testing your setup to avoid hitting request limits
 
 if [ -d "$data_path" ]; then
   read -p "Existing data found for $domains. Continue and replace existing certificate? (y/N) " decision


### PR DESCRIPTION
Let's crypt init. script fix. Without it certificate may become self-signed.